### PR TITLE
Update entity creation to match draft-js API changes

### DIFF
--- a/lib/camelCase.js
+++ b/lib/camelCase.js
@@ -9,7 +9,7 @@ Object.defineProperty(exports, "__esModule", {
  * @return {String} UnderScore is now CamelCased
  */
 function camelCase(str) {
-  var capitaliseLead = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+  var capitaliseLead = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
   str = str.replace(/_([a-z])/g, function (group) {
     if (group[1]) {

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -29,8 +29,9 @@ function compiler(ast) {
   var config = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
   /**
-   * Create a ContentState object
+   * Create an empty ContentState object
    */
+  var entityContentState = _draftJs.ContentState.createFromText('');
 
   /**
    * Called for each node in the abstract syntax tree (AST) that makes up the
@@ -125,12 +126,13 @@ function compiler(ast) {
       // Create the entity and note its key
       // run over all the children and aggregate them into the
       // format we need for the final parent block
-      var entity = _draftJs.Entity.create(type, mutability, data);
+      entityContentState = entityContentState.createEntity(type, mutability, data);
+      var entityKey = entityContentState.getLastCreatedEntityKey();
       var text = '';
       var characterList = (0, _immutable.List)();
 
       children.forEach(function (child) {
-        var childData = visit(child, { entity: entity });
+        var childData = visit(child, { entityKey: entityKey });
         // Combine the text and the character list
         text = text + childData.text;
         characterList = characterList.concat(childData.characterList);
@@ -168,7 +170,7 @@ function compiler(ast) {
       // Create a List that has the style values for each character
       var charMetadata = _draftJs.CharacterMetadata.create({
         style: style,
-        entity: opts.entity || null
+        entity: opts.entityKey || null
       });
 
       // We want the styles to apply to the entire range of `text`
@@ -183,10 +185,15 @@ function compiler(ast) {
     }
   };
 
-  // Procedurally visit each node
-  var blocks = (0, _flatten2.default)(ast.map(visit));
-
-  return blocks;
+  if (ast.length > 0) {
+    // Procedurally visit each node
+    var blocks = (0, _flatten2.default)(ast.map(visit));
+    // Build a valid ContentState that combines the blocks and the entity map
+    // from the entityContentState
+    return _draftJs.ContentState.createFromBlockArray(blocks, entityContentState.getEntityMap());
+  } else {
+    return _draftJs.ContentState.createFromText('');
+  }
 }
 
 exports.default = compiler;

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -26,7 +26,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * Compiler
  */
 function compiler(ast) {
-  var config = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+  var config = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+  /**
+   * Create a ContentState object
+   */
 
   /**
    * Called for each node in the abstract syntax tree (AST) that makes up the
@@ -62,11 +66,13 @@ function compiler(ast) {
      * @return {Function} Result of the relevant `renderers.block[type]`
      * function
      */
+
     visitBlock: function visitBlock(node, opts) {
       var childBlocks = [];
       var depth = opts.depth || 0;
       var type = node[_dataSchema2.default.block.type];
       var children = node[_dataSchema2.default.block.children];
+      var data = (0, _immutable.Map)(node[_dataSchema2.default.block.data]);
 
       // Build up block content
       var text = '';
@@ -91,7 +97,8 @@ function compiler(ast) {
         text: text,
         type: type,
         characterList: characterList,
-        depth: depth
+        depth: depth,
+        data: data
       });
 
       return [contentBlock, childBlocks];
@@ -148,7 +155,7 @@ function compiler(ast) {
      * function
      */
     visitInline: function visitInline(node) {
-      var opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+      var opts = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
       var styles = node[_dataSchema2.default.inline.styles];
       var text = node[_dataSchema2.default.inline.text];

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,28 +4,13 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _draftJs = require('draft-js');
-
 var _compiler = require('./compiler');
 
-var _compiler2 = _interopRequireDefault(_compiler);
+Object.defineProperty(exports, 'default', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_compiler).default;
+  }
+});
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
-/**
- * Importer
- * @param  {Array} ast Abstract Syntax Tree representing draft-js state
- * @return {ContentState} A draft-js `ContentState` object
- */
-function importer(ast) {
-  var blocks = (0, _compiler2.default)(ast);
-  // Ensure we return a valid `ContentState` object whether or not there's
-  // any content
-  if (blocks.length > 0) {
-    return _draftJs.ContentState.createFromBlockArray(blocks);
-  } else {
-    return _draftJs.ContentState.createFromText('');
-  }
-}
-
-exports.default = importer;

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   },
   "homepage": "https://github.com/icelab/draft-js-ast-importer",
   "dependencies": {
-    "draft-js-utils": "^0.1.4",
+    "draft-js-utils": "^0.1.7",
     "immutable": "^3.8.1"
   },
   "peerDependencies": {
-    "draft-js": ">=0.8.0"
+    "draft-js": ">=0.10.0"
   },
   "devDependencies": {
     "babel-cli": "6.7.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,4 @@
-import {ContentState} from 'draft-js'
-import compiler from './compiler'
-
 /**
- * Importer
- * @param  {Array} ast Abstract Syntax Tree representing draft-js state
- * @return {ContentState} A draft-js `ContentState` object
+ * Export the compiler directly
  */
-function importer (ast) {
-  const blocks = compiler(ast)
-  // Ensure we return a valid `ContentState` object whether or not there's
-  // any content
-  if (blocks.length > 0) {
-    return ContentState.createFromBlockArray(blocks)
-  } else {
-    return ContentState.createFromText('')
-  }
-}
-
-export default importer
+export {default as default} from './compiler'

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import test from 'tape'
 import {
   convertToRaw,
+  ContentState,
   EditorState,
 } from 'draft-js'
 import importer from '../src'
@@ -43,6 +44,15 @@ test('it should export data', (nest) => {
       actual,
       expected,
       'converted data includes correct nested depth values'
+    )
+    assert.end()
+  })
+
+  nest.test('... return a valid ContentState given an empty AST', (assert) => {
+    const contentState = importer([])
+    assert.notOk(
+      contentState.hasText(),
+      'an empty content state is created'
     )
     assert.end()
   })


### PR DESCRIPTION
[As of v0.10.0 draft-js entities are contained within the contentState object rather than a global registry](https://facebook.github.io/draft-js/docs/v0-10-api-migration.html#creating-an-entity). To create entities correctly we use a throwaway contentState object to create our entities before merging them with any created blocks.