### PR TITLE
Upgrade draft-js-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,9 +1805,9 @@
       }
     },
     "draft-js-utils": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-0.1.7.tgz",
-      "integrity": "sha1-4raSfKYg7fGFWkv8HPHSEICnDxY="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-1.4.0.tgz",
+      "integrity": "sha512-8s9FFuKC+lOWGwJ0b3om2PF+uXrqQPaEQlPJI7UxdzxTYGMeKouMPA9+YlPn52zcAVElIZtd2tXj6eQmvlKelw=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/icelab/draft-js-ast-importer",
   "dependencies": {
-    "draft-js-utils": "^0.1.7",
+    "draft-js-utils": "^1.4.0",
     "immutable": "~3.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
Ref https://github.com/icelab/draft-js-ast-exporter/pull/10

I added esm support to this package too.

/cc @makenosound 