### PR TITLE
Remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1804,11 +1804,6 @@
         "object-assign": "^4.1.0"
       }
     },
-    "draft-js-utils": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/draft-js-utils/-/draft-js-utils-0.1.7.tgz",
-      "integrity": "sha1-4raSfKYg7fGFWkv8HPHSEICnDxY="
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "homepage": "https://github.com/icelab/draft-js-ast-importer",
   "dependencies": {
-    "draft-js-utils": "^0.1.7",
     "immutable": "~3.7.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
We don’t actually use `draft-js-utils` in this repo. Think it was likely cargo-culted across from the equivalent exporter.